### PR TITLE
feat: add move & delete actions to TaskCard (#4)

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -1,10 +1,29 @@
-export default function TaskCard({ title, assignee, dueDate }) {
-    return(
-        <article className="task-card">
-            <h3>{title}</h3>
-            <p>
-                {assignee} · Due {dueDate}
-            </p>
-        </article>
-    )
+const STATUS_ORDER = ["todo", "doing", "done"];
+
+export default function TaskCard({ id, title, assignee, dueDate, status, onMove, onDelete }) {
+  const idx = STATUS_ORDER.indexOf(status);
+  const canMoveLeft = idx > 0;
+  const canMoveRight = idx < STATUS_ORDER.length - 1;
+
+  function handleDelete() {
+    if (window.confirm(`Delete "${title}"?`)) {
+      onDelete(id);
+    }
+  }
+
+  return (
+    <article className="task-card">
+      <h3>{title}</h3>
+      <p>{assignee} · Due {dueDate}</p>
+      <div className="task-card-actions">
+        {canMoveLeft && (
+          <button onClick={() => onMove(id, STATUS_ORDER[idx - 1])}>← Move</button>
+        )}
+        {canMoveRight && (
+          <button onClick={() => onMove(id, STATUS_ORDER[idx + 1])}>Move →</button>
+        )}
+        <button className="delete-btn" onClick={handleDelete}>Delete</button>
+      </div>
+    </article>
+  );
 }

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -1,6 +1,14 @@
 const STATUS_ORDER = ["todo", "doing", "done"];
 
-export default function TaskCard({ id, title, assignee, dueDate, status, onMove, onDelete }) {
+export default function TaskCard({
+  id,
+  title,
+  assignee,
+  dueDate,
+  status,
+  onMove,
+  onDelete,
+}) {
   const idx = STATUS_ORDER.indexOf(status);
   const canMoveLeft = idx > 0;
   const canMoveRight = idx < STATUS_ORDER.length - 1;
@@ -14,15 +22,23 @@ export default function TaskCard({ id, title, assignee, dueDate, status, onMove,
   return (
     <article className="task-card">
       <h3>{title}</h3>
-      <p>{assignee} · Due {dueDate}</p>
+      <p>
+        {assignee} · Due {dueDate}
+      </p>
       <div className="task-card-actions">
         {canMoveLeft && (
-          <button onClick={() => onMove(id, STATUS_ORDER[idx - 1])}>← Move</button>
+          <button onClick={() => onMove(id, STATUS_ORDER[idx - 1])}>
+            ← Move
+          </button>
         )}
         {canMoveRight && (
-          <button onClick={() => onMove(id, STATUS_ORDER[idx + 1])}>Move →</button>
+          <button onClick={() => onMove(id, STATUS_ORDER[idx + 1])}>
+            Move →
+          </button>
         )}
-        <button className="delete-btn" onClick={handleDelete}>Delete</button>
+        <button className="delete-btn" onClick={handleDelete}>
+          Delete
+        </button>
       </div>
     </article>
   );


### PR DESCRIPTION
## Summary
  - Updated `TaskCard` component with move left/right and delete buttons
  - Move buttons respect status boundaries (no left on To Do, no right on Done)
  - Delete button shows a confirmation prompt before removing the task
  - Wired `BoardPage` with 3 columns (To Do / Doing / Done) with per-column task count
  - Seeded 9 mock tasks across all statuses for testing

  Closes #4