### PR TITLE
Board + Column layout (Board/Column)feat(board): render 3 columns with per-column counts and flexbox layout

### DIFF
--- a/src/components/Board.jsx
+++ b/src/components/Board.jsx
@@ -1,0 +1,18 @@
+import { mockTasks } from "../data/mockTasks";
+import Column from "./Column";
+
+function Board() {
+  const todoTasks = mockTasks.filter((task) => task.status === "todo");
+  const doingTasks = mockTasks.filter((task) => task.status === "doing");
+  const doneTasks = mockTasks.filter((task) => task.status === "done");
+
+  return (
+    <div style={{ display: "flex", gap: "24px", padding: "16px" }}>
+      <Column title="To Do" tasks={todoTasks} />
+      <Column title="Doing" tasks={doingTasks} />
+      <Column title="Done" tasks={doneTasks} />
+    </div>
+  );
+}
+
+export default Board;

--- a/src/components/Board.jsx
+++ b/src/components/Board.jsx
@@ -1,18 +1,29 @@
-import { mockTasks } from "../data/mockTasks";
+import { useTasks } from "../hooks/useTasks";
 import Column from "./Column";
 
-function Board() {
-  const todoTasks = mockTasks.filter((task) => task.status === "todo");
-  const doingTasks = mockTasks.filter((task) => task.status === "doing");
-  const doneTasks = mockTasks.filter((task) => task.status === "done");
+const COLUMNS = [
+  { key: "todo", label: "To Do" },
+  { key: "doing", label: "Doing" },
+  { key: "done", label: "Done" },
+];
+
+export default function Board() {
+  const { tasks, dispatch } = useTasks();
+
+  const handleMove = (id, status) => dispatch({ type: "moved", id, status });
+  const handleDelete = (id) => dispatch({ type: "deleted", id });
 
   return (
     <div style={{ display: "flex", gap: "24px", padding: "16px" }}>
-      <Column title="To Do" tasks={todoTasks} />
-      <Column title="Doing" tasks={doingTasks} />
-      <Column title="Done" tasks={doneTasks} />
+      {COLUMNS.map((col) => (
+        <Column
+          key={col.key}
+          title={col.label}
+          tasks={tasks.filter((t) => t.status === col.key)}
+          onMove={handleMove}
+          onDelete={handleDelete}
+        />
+      ))}
     </div>
   );
 }
-
-export default Board;

--- a/src/components/Column.jsx
+++ b/src/components/Column.jsx
@@ -1,0 +1,18 @@
+import TaskCard from "./TaskCard";
+function Column({ title, tasks }) {
+  return (
+    <div style={{ background: "#f4f4f4", color: "#222", borderRadius: "8px", padding: "12px", minWidth: "220px" }}>
+      <h2 style={{ color: "#222" }}>{title} ({tasks.length})</h2>
+      {tasks.map((task) => (
+        <TaskCard
+          key={task.id}
+          title={task.title}
+          assignee={task.assignee}
+          dueDate={task.dueDate}
+        />
+      ))}
+    </div>
+  );
+}
+
+export default Column;

--- a/src/components/Column.jsx
+++ b/src/components/Column.jsx
@@ -1,18 +1,31 @@
 import TaskCard from "./TaskCard";
-function Column({ title, tasks }) {
+
+export default function Column({ title, tasks, onMove, onDelete }) {
   return (
-    <div style={{ background: "#f4f4f4", color: "#222", borderRadius: "8px", padding: "12px", minWidth: "220px" }}>
-      <h2 style={{ color: "#222" }}>{title} ({tasks.length})</h2>
+    <div
+      style={{
+        background: "#f4f4f4",
+        color: "#222",
+        borderRadius: "8px",
+        padding: "12px",
+        minWidth: "220px",
+      }}
+    >
+      <h2 style={{ color: "#222" }}>
+        {title} ({tasks.length})
+      </h2>
       {tasks.map((task) => (
         <TaskCard
           key={task.id}
+          id={task.id}
           title={task.title}
           assignee={task.assignee}
           dueDate={task.dueDate}
+          status={task.status}
+          onMove={onMove}
+          onDelete={onDelete}
         />
       ))}
     </div>
   );
 }
-
-export default Column;

--- a/src/pages/BoardPage.jsx
+++ b/src/pages/BoardPage.jsx
@@ -1,3 +1,6 @@
+// src/pages/BoardPage.jsx
+import Board from "../components/Board";
+
 export default function BoardPage() {
-  return <h1>Board</h1>;
+  return <Board />;
 }


### PR DESCRIPTION
- Board renders 3 columns (To Do / Doing / Done)
  - Column shows title + per-column count
  - Tasks filtered by status, stable key={task.id}
  - Flexbox layout, 9 mock tasks across all columns

  Closes #3