### PR TITLE
feat: add controlled create-task form with validation

### DIFF
--- a/src/pages/NewTaskPage.jsx
+++ b/src/pages/NewTaskPage.jsx
@@ -12,6 +12,7 @@ export default function NewTaskPage() {
   const [dueDate, setDueDate] = useState("");
   const [errors, setErrors] = useState({});
   const [submitting, setSubmitting] = useState(false);
+  const today = new Date().toLocaleDateString("en-CA"); // local YYYY-MM-DD
 
   function validate() {
     const next = {};
@@ -20,7 +21,7 @@ export default function NewTaskPage() {
     }
     if (!dueDate) {
       next.dueDate = "Due date is required.";
-    } else if (dueDate < new Date().toISOString().slice(0, 10)) {
+    } else if (dueDate < today) {
       next.dueDate = "Due date can't be in the past.";
     }
     return next;
@@ -71,6 +72,7 @@ export default function NewTaskPage() {
           <input
             id="dueDate"
             type="date"
+            min={today}
             value={dueDate}
             onChange={(e) => setDueDate(e.target.value)}
           />

--- a/src/pages/NewTaskPage.jsx
+++ b/src/pages/NewTaskPage.jsx
@@ -1,3 +1,86 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { createTask } from "../api/tasks";
+import { useTasks } from "../hooks/useTasks";
+
 export default function NewTaskPage() {
-  return <h1>New Task</h1>;
+  const { dispatch } = useTasks();
+  const navigate = useNavigate();
+
+  const [title, setTitle] = useState("");
+  const [assignee, setAssignee] = useState("");
+  const [dueDate, setDueDate] = useState("");
+  const [errors, setErrors] = useState({});
+  const [submitting, setSubmitting] = useState(false);
+
+  function validate() {
+    const next = {};
+    if (title.trim().length < 3) {
+      next.title = "Title is required and must be at least 3 characters.";
+    }
+    if (!dueDate) {
+      next.dueDate = "Due date is required.";
+    } else if (dueDate < new Date().toISOString().slice(0, 10)) {
+      next.dueDate = "Due date can't be in the past.";
+    }
+    return next;
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    const validationErrors = validate();
+    setErrors(validationErrors);
+    if (Object.keys(validationErrors).length > 0) return;
+
+    setSubmitting(true);
+    const task = await createTask({
+      title: title.trim(),
+      assignee: assignee.trim() || "Unassigned",
+      status: "todo",
+      dueDate,
+    });
+    dispatch({ type: "added", task });
+    navigate("/");
+  }
+
+  return (
+    <div>
+      <h1>New Task</h1>
+      <form onSubmit={handleSubmit} noValidate>
+        <div>
+          <label htmlFor="title">Title</label>
+          <input
+            id="title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+          {errors.title && <p role="alert">{errors.title}</p>}
+        </div>
+
+        <div>
+          <label htmlFor="assignee">Assignee</label>
+          <input
+            id="assignee"
+            value={assignee}
+            onChange={(e) => setAssignee(e.target.value)}
+          />
+        </div>
+
+        <div>
+          <label htmlFor="dueDate">Due date</label>
+          <input
+            id="dueDate"
+            type="date"
+            value={dueDate}
+            onChange={(e) => setDueDate(e.target.value)}
+          />
+          {errors.dueDate && <p role="alert">{errors.dueDate}</p>}
+        </div>
+
+        <button type="submit" disabled={submitting}>
+          {submitting ? "Adding..." : "Add task"}
+        </button>
+      </form>
+    </div>
+  );
 }


### PR DESCRIPTION
Closes #5

- Controlled form (title, assignee, due date) in NewTaskPage
- Validates title (required, min 3 chars) and due date (not in the past) with inline error messages
- On valid submit: createTask() -> dispatch({ type: 'added', task }) -> new task appears in To Do