### PR TITLE
feat: wire four UI states on board load

### DIFF
--- a/src/context/TasksProvider.jsx
+++ b/src/context/TasksProvider.jsx
@@ -1,9 +1,11 @@
-import { useReducer } from "react";
+import { useReducer, useEffect, useState } from "react";
 import { TasksContext } from "./TasksContext";
-import { mockTasks } from "../data/mockTasks";
+import { getTasks } from "../api/tasks";
 
 function tasksReducer(state, action) {
   switch (action.type) {
+    case "loaded":
+      return action.tasks;
     case "added":
       return [...state, action.task];
     case "moved":
@@ -18,9 +20,30 @@ function tasksReducer(state, action) {
 }
 
 export function TasksProvider({ children }) {
-  const [tasks, dispatch] = useReducer(tasksReducer, mockTasks);
+  const [tasks, dispatch] = useReducer(tasksReducer, []);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  function loadTasks() {
+    setLoading(true);
+    setError(null);
+    getTasks()
+      .then((data) => {
+        dispatch({ type: "loaded", tasks: data });
+        setLoading(false);
+      })
+      .catch((err) => {
+        setError(err.message || "Failed to load tasks");
+        setLoading(false);
+      });
+  }
+
+  useEffect(() => {
+    loadTasks();
+  }, []);
+
   return (
-    <TasksContext.Provider value={{ tasks, dispatch }}>
+    <TasksContext.Provider value={{ tasks, dispatch, loading, error, retry: loadTasks }}>
       {children}
     </TasksContext.Provider>
   );

--- a/src/context/TasksProvider.jsx
+++ b/src/context/TasksProvider.jsx
@@ -1,4 +1,4 @@
-import { useReducer, useEffect, useState } from "react";
+import { useReducer, useEffect, useState, useCallback } from "react";
 import { TasksContext } from "./TasksContext";
 import { getTasks } from "../api/tasks";
 
@@ -24,9 +24,7 @@ export function TasksProvider({ children }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  function loadTasks() {
-    setLoading(true);
-    setError(null);
+  const loadTasks = useCallback(() => {
     getTasks()
       .then((data) => {
         dispatch({ type: "loaded", tasks: data });
@@ -36,14 +34,20 @@ export function TasksProvider({ children }) {
         setError(err.message || "Failed to load tasks");
         setLoading(false);
       });
-  }
+  }, []);
 
   useEffect(() => {
     loadTasks();
-  }, []);
+  }, [loadTasks]);
+
+  function retry() {
+    setLoading(true);
+    setError(null);
+    loadTasks();
+  }
 
   return (
-    <TasksContext.Provider value={{ tasks, dispatch, loading, error, retry: loadTasks }}>
+    <TasksContext.Provider value={{ tasks, dispatch, loading, error, retry }}>
       {children}
     </TasksContext.Provider>
   );

--- a/src/pages/BoardPage.jsx
+++ b/src/pages/BoardPage.jsx
@@ -1,6 +1,25 @@
-// src/pages/BoardPage.jsx
+import { useTasks } from "../hooks/useTasks";
 import Board from "../components/Board";
 
 export default function BoardPage() {
+  const { tasks, loading, error, retry } = useTasks();
+
+  if (loading) {
+    return <p style={{ padding: "16px" }}>Loading tasks…</p>;
+  }
+
+  if (error) {
+    return (
+      <div style={{ padding: "16px" }}>
+        <p>Error: {error}</p>
+        <button onClick={retry}>Retry</button>
+      </div>
+    );
+  }
+
+  if (tasks.length === 0) {
+    return <p style={{ padding: "16px" }}>No tasks yet. Create one to get started!</p>;
+  }
+
   return <Board />;
 }


### PR DESCRIPTION
## Summary
  - TasksProvider now loads tasks via API with artificial delay (400ms)
  - BoardPage renders four UI states: loading, error, empty, success
  - Error state includes a Retry button
  - Added `loaded` action to the tasks reducer

  Partial #7