### PR TITLE
style: theme the top nav (Board / New task)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,8 +9,21 @@ export default function App() {
   return (
     <TasksProvider>
       <BrowserRouter>
-        <nav>
-          <Link to="/">Board</Link> · <Link to="/tasks/new">New task</Link>
+        <nav className="sticky top-0 z-10 border-b border-slate-800 bg-slate-950/80 backdrop-blur">
+          <div className="max-w-7xl mx-auto px-4 py-3 flex items-center gap-2">
+            <Link
+              to="/"
+              className="px-3 py-1.5 rounded-lg text-sm font-medium text-slate-300 hover:bg-slate-800 hover:text-slate-100 transition-colors"
+            >
+              Board
+            </Link>
+            <Link
+              to="/tasks/new"
+              className="px-3 py-1.5 rounded-lg text-sm font-medium bg-blue-600 text-white hover:bg-blue-700 transition-colors"
+            >
+              New task
+            </Link>
+          </div>
         </nav>
         <Routes>
           <Route path="/" element={<BoardPage />} />


### PR DESCRIPTION
## Summary
Styles the top nav to match the app's dark slate + indigo theme - it was still the plain unstyled `Board · New task` links. Styling only, no routing/logic changes.

## Changes
- `App.jsx`: replaced the bare `<nav>` with a **sticky dark top bar** (slate palette, border, backdrop-blur) aligned to the board's `max-w-7xl` width
- **Board** > subtle slate nav link with hover state
- **New task** > primary blue button (matches the `Button` component's primary color)

## Verification
- `npm run dev` - nav is themed; both links navigate (Board > `/`, New task → `/tasks/new`)
- `npm run lint` clean, Prettier applied