### PR TITLE
feat: add dev-only error UI demo via ?fail query param

### DIFF
--- a/client/src/api/tasks.js
+++ b/client/src/api/tasks.js
@@ -3,8 +3,14 @@ import { mockTasks } from "../data/mockTasks";
 const delay = (data, ms = 400) =>
   new Promise((resolve) => setTimeout(() => resolve(data), ms));
 
+const fail = (ms = 400) =>
+  new Promise((_, reject) =>
+    setTimeout(() => reject(new Error("Simulated network error")), ms),
+  );
+
 export function getTasks() {
-  return delay([...mockTasks]);
+  const shouldFail = new URLSearchParams(window.location.search).has("fail");
+  return shouldFail ? fail() : delay([...mockTasks]);
 }
 
 export function createTask(data) {


### PR DESCRIPTION
## Summary
  - Added a `?fail` query parameter to `getTasks()` that simulates a network error
  - Visiting `/?fail` triggers the error UI state (error message + Retry button)
  - Removing the param and clicking Retry recovers to the normal board

  ## How to test
  1. Run `npm run dev`
  2. Visit `http://localhost:5173/?fail` → error state shown
  3. Remove `?fail` from URL, click **Retry** → board loads normally

  Closes #25