### PR TITLE
feat: task-detail loading spinner (no not-found flash) + reusable Spinner

### DIFF
--- a/client/src/components/Spinner.jsx
+++ b/client/src/components/Spinner.jsx
@@ -1,0 +1,9 @@
+export default function Spinner({ className = "h-6 w-6" }) {
+  return (
+    <div
+      role="status"
+      aria-label="Loading"
+      className={`${className} animate-spin rounded-full border-[3px] border-slate-700 border-t-indigo-400`}
+    />
+  );
+}

--- a/client/src/pages/BoardPage.jsx
+++ b/client/src/pages/BoardPage.jsx
@@ -1,6 +1,7 @@
 import { useTasks } from "../hooks/useTasks";
 import Board from "../components/Board";
 import Button from "../components/Button";
+import Spinner from "../components/Spinner";
 
 export default function BoardPage() {
   const { tasks, loading, error, retry } = useTasks();
@@ -8,9 +9,7 @@ export default function BoardPage() {
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-[50vh]">
-        <p className="text-slate-400 font-medium animate-pulse">
-          Loading tasks...
-        </p>
+        <Spinner />
       </div>
     );
   }

--- a/client/src/pages/TaskDetailPage.jsx
+++ b/client/src/pages/TaskDetailPage.jsx
@@ -1,12 +1,21 @@
 import { useParams, Link } from "react-router-dom";
 import { useTasks } from "../hooks/useTasks";
+import Spinner from "../components/Spinner";
 
 export default function TaskDetailPage() {
   const { id } = useParams();
-  const { tasks } = useTasks();
+  const { tasks, loading } = useTasks();
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <Spinner />
+      </div>
+    );
+  }
+
   const task = tasks.find((t) => t.id === id);
 
-  // TODO: when real API is wired, !task is true during loading — add a loading state to avoid flashing "not found"
   if (!task) {
     return (
       <div className="flex flex-col items-center justify-center min-h-[50vh] p-4">


### PR DESCRIPTION
## Summary
Fixes the "Task not found" flash when deep-linking/refreshing `/tasks/:id`, and extracts a reusable `Spinner` used across loading states.

## Changes
- `TaskDetailPage` now reads `loading` from `useTasks()` and shows a spinner **before** deciding "not found" - no more flash on refresh/deep-link
- Added `components/Spinner.jsx` - a dark-theme spinner (`role="status"`, optional size)
- `BoardPage` loading state swapped from "Loading tasks…" text to the shared `<Spinner />` for consistency

## Verification
- Refresh/deep-link a valid `/tasks/:id` > spinner > task (no "not found" flash) 
- Bad id > after loading, "Task not found" (no crash) 
- Board first load > spinner
- `npm run lint` clean

Closes #26

Also touches `BoardPage.jsx` (the loading-state consistency swap) - slightly broader than #26, but keeps both spinners identical.