### PR TITLE
feat: API client helper + dev proxy

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=

--- a/client/src/api/client.js
+++ b/client/src/api/client.js
@@ -1,0 +1,31 @@
+const BASE = import.meta.env.VITE_API_URL || "";
+
+export async function request(path, options = {}) {
+  const token = localStorage.getItem("token");
+
+  const headers = {
+    "Content-Type": "application/json",
+    ...options.headers,
+  };
+
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  const res = await fetch(`${BASE}${path}`, { ...options, headers });
+
+  if (res.status === 204) return null;
+
+  if (res.status === 401) {
+    localStorage.removeItem("token");
+    window.dispatchEvent(new Event("auth:expired"));
+    throw new Error("Unauthorized");
+  }
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.message || `Request failed: ${res.status}`);
+  }
+
+  return res.json();
+}

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -5,4 +5,9 @@ import tailwindcss from "@tailwindcss/vite";
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  server: {
+    proxy: {
+      "/api": "http://localhost:4000",
+    },
+  },
 });

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -7,7 +7,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   server: {
     proxy: {
-      "/api": "http://localhost:4000",
+      "/api": { target: "http://localhost:4000", changeOrigin: true },
     },
   },
 });


### PR DESCRIPTION
"Closes #47

  ## Summary
  - Add request() helper in client/src/api/client.js with Bearer token, 401 handling, and auth:expired event
  - Add Vite dev proxy: /api → http://localhost:4000

  ## Test plan
  - [x] request('/api/test') returns JSON through proxy
  - [x] 401 response clears token and fires auth:expired"