### PR TITLE
feat: add name field to user registration and JWT payload (#61)

### DIFF
--- a/client/src/components/NavBar.jsx
+++ b/client/src/components/NavBar.jsx
@@ -32,8 +32,10 @@ export default function NavBar() {
         <div className="ml-auto flex items-center gap-2">
           {token ? (
             <>
-              {user?.email && (
-                <span className="text-sm text-slate-400">{user.email}</span>
+              {(user?.name || user?.email) && (
+                <span className="text-sm text-slate-400">
+                  {user?.name || user?.email}
+                </span>
               )}
               <button
                 onClick={handleLogout}

--- a/client/src/pages/RegisterPage.jsx
+++ b/client/src/pages/RegisterPage.jsx
@@ -4,6 +4,7 @@ import { registerApi, loginApi } from "../api/auth";
 import { useAuth } from "../hooks/useAuth";
 
 export default function RegisterPage() {
+  const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
@@ -17,7 +18,7 @@ export default function RegisterPage() {
     setError("");
     setLoading(true);
     try {
-      await registerApi({ email, password });
+      await registerApi({ name, email, password });
       // register returns { user } with no token — log in right after to get one
       const data = await loginApi({ email, password });
       login(data.user, data.token);
@@ -43,6 +44,20 @@ export default function RegisterPage() {
         )}
 
         <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-slate-300">
+              Name
+            </label>
+            <input
+              type="text"
+              required
+              minLength={2}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="mt-1 w-full rounded-md border border-slate-700 bg-slate-800 p-2 text-sm text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
           <div>
             <label className="block text-sm font-medium text-slate-300">
               Email

--- a/server/src/middleware/authenticate.js
+++ b/server/src/middleware/authenticate.js
@@ -9,7 +9,7 @@ export function authenticate(req, res, next) {
   }
   try {
     const payload = jwt.verify(token, config.jwtSecret);
-    req.user = { id: payload.sub, email: payload.email };
+    req.user = { id: payload.sub, email: payload.email, name: payload.name };
     next();
   } catch (err) {
     const expired = err.name === "TokenExpiredError";

--- a/server/src/repositories/user.repo.js
+++ b/server/src/repositories/user.repo.js
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 // In-memory store (M2 stage - no DB driver wired up yet).
-// email -> user record: { id, email, passwordHash, createdAt }
+// email -> user record: { id, name, email, passwordHash, createdAt }
 const usersByEmail = new Map();
 
 export const userRepository = {
@@ -9,9 +9,10 @@ export const userRepository = {
     return usersByEmail.get(email) ?? null;
   },
 
-  create({ email, passwordHash }) {
+  create({ email, passwordHash, name }) {
     const user = {
       id: randomUUID(),
+      name,
       email,
       passwordHash,
       createdAt: new Date().toISOString(),

--- a/server/src/schemas/auth.schema.js
+++ b/server/src/schemas/auth.schema.js
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 export const registerSchema = z.object({
+  name: z.string().trim().min(2, "Name must be at least 2 characters"),
   email: z.string().trim().toLowerCase().email("Invalid email address"),
   password: z.string().min(8, "Password must be at least 8 characters"),
 });

--- a/server/src/services/auth.service.js
+++ b/server/src/services/auth.service.js
@@ -13,14 +13,14 @@ export function publicUser(user) {
   return safe;
 }
 
-export async function register({ email, password }) {
+export async function register({ name, email, password }) {
   const existing = userRepository.findByEmail(email);
   if (existing) {
     throw new AppError("Email already in use", 409, "EMAIL_IN_USE");
   }
 
   const passwordHash = await bcrypt.hash(password, SALT_ROUNDS);
-  const user = userRepository.create({ email, passwordHash });
+  const user = userRepository.create({ email, passwordHash, name });
 
   return publicUser(user);
 }
@@ -37,7 +37,7 @@ export async function login({ email, password }) {
   }
 
   const token = jwt.sign(
-    { sub: user.id, email: user.email },
+    { sub: user.id, email: user.email, name: user.name },
     config.jwtSecret,
     {
       expiresIn: TOKEN_EXPIRY,


### PR DESCRIPTION
## Summary
  - Added `name` field to registration schema with min 2 character validation
  - Updated user repository to store `name` in user records
  - Included `name` in JWT payload so `/me` endpoint returns it without a DB lookup
  - Added `name` to `req.user` in authenticate middleware
  - Added Name input field to client RegisterPage

  ## Related Issue
  Closes #61

  ## Test Plan
  - [x] `POST /register` with name → 201, response includes `name`
  - [x] `POST /register` without name → 400 validation error
  - [x] `POST /register` with 1-char name → 400 validation error
  - [x] `POST /login` → token + user with `name`
  - [x] `GET /me` → user with `name`