### PR TITLE
feat: ownership checks + login rate-limit

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,3 +1,4 @@
 PORT=4000
 JWT_SECRET=
 CLIENT_ORIGIN=http://localhost:5173
+NODE_ENV=

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -13,6 +13,7 @@
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
+        "express-rate-limit": "^8.7.0",
         "jsonwebtoken": "^9.0.3",
         "zod": "^4.4.3"
       }
@@ -341,6 +342,25 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
+      "integrity": "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -503,6 +523,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/server/package.json
+++ b/server/package.json
@@ -30,6 +30,7 @@
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.7.0",
     "jsonwebtoken": "^9.0.3",
     "zod": "^4.4.3"
   }

--- a/server/src/controllers/task.controller.js
+++ b/server/src/controllers/task.controller.js
@@ -2,22 +2,22 @@ import { asyncHandler } from "../utils/asyncHandler.js";
 import * as taskService from "../services/task.service.js";
 
 export const create = asyncHandler(async (req, res) => {
-  const task = taskService.createTask(req.body);
+  const task = taskService.createTask(req.body, req.user.id);
   res.status(201).json(task);
 });
 
 export const update = asyncHandler(async (req, res) => {
-  const task = taskService.updateTask(req.params.id, req.body);
+  const task = taskService.updateTask(req.params.id, req.body, req.user.id);
   res.status(200).json(task);
 });
 
 export const remove = asyncHandler(async (req, res) => {
-  taskService.deleteTask(req.params.id);
+  taskService.deleteTask(req.params.id, req.user.id);
   res.status(204).send();
 });
 
 // GET /api/boards/:id/tasks  (id = boardId)
 export const listByBoard = asyncHandler(async (req, res) => {
-  const tasks = taskService.listTasks(req.params.id, req.query);
+  const tasks = taskService.listTasks(req.params.id, req.user.id, req.query);
   res.status(200).json(tasks);
 });

--- a/server/src/middleware/loginLimiter.js
+++ b/server/src/middleware/loginLimiter.js
@@ -2,8 +2,11 @@ import rateLimit from "express-rate-limit";
 
 export const loginLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute
-  max: 5, // 5 attempts per IP per minute
+  max: process.env.NODE_ENV === "test" ? 1000 : 5, // relax in tests (M4 Supertest)
   standardHeaders: true,
   legacyHeaders: false,
-  message: { message: "Too many login attempts, please try again later." },
+  message: {
+    message: "Too many login attempts, please try again later.",
+    code: "RATE_LIMITED",
+  },
 });

--- a/server/src/middleware/loginLimiter.js
+++ b/server/src/middleware/loginLimiter.js
@@ -1,0 +1,9 @@
+import rateLimit from "express-rate-limit";
+
+export const loginLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 5, // 5 attempts per IP per minute
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { message: "Too many login attempts, please try again later." },
+});

--- a/server/src/repositories/board.repo.js
+++ b/server/src/repositories/board.repo.js
@@ -5,4 +5,6 @@ export const createBoard = (board) => {
   return board;
 };
 
+export const findById = (id) => boards.find((b) => b.id === id) ?? null;
+
 export const listBoards = () => boards;

--- a/server/src/routes/auth.routes.js
+++ b/server/src/routes/auth.routes.js
@@ -1,11 +1,12 @@
 import { Router } from "express";
 import { authenticate } from "../middleware/authenticate.js";
 import { validate } from "../middleware/validate.js";
+import { loginLimiter } from "../middleware/loginLimiter.js";
 import { registerSchema, loginSchema } from "../schemas/auth.schema.js";
 import * as controller from "../controllers/auth.controller.js";
 
 const router = Router();
 router.post("/register", validate(registerSchema), controller.register);
-router.post("/login", validate(loginSchema), controller.login);
+router.post("/login", loginLimiter, validate(loginSchema), controller.login);
 router.get("/me", authenticate, controller.me); // protected at route level
 export default router;

--- a/server/src/services/board.service.js
+++ b/server/src/services/board.service.js
@@ -1,5 +1,13 @@
 import { randomUUID } from "node:crypto";
 import * as boardRepo from "../repositories/board.repo.js";
+import { NotFoundError, ForbiddenError } from "../utils/AppError.js";
+
+export function assertMember(boardId, userId) {
+  const board = boardRepo.findById(boardId);
+  if (!board) throw new NotFoundError("Board");
+  if (!board.members.includes(userId)) throw new ForbiddenError();
+  return board;
+}
 
 export function createBoard(userId, { name }) {
   const board = {

--- a/server/src/services/task.service.js
+++ b/server/src/services/task.service.js
@@ -1,9 +1,10 @@
 import { randomUUID } from "node:crypto";
 import { taskRepository } from "../repositories/task.repo.js";
 import { NotFoundError } from "../utils/AppError.js";
+import { assertMember } from "./board.service.js";
 
-// NOTE: CRUD only
-export function createTask(data) {
+export function createTask(data, userId) {
+  assertMember(data.boardId, userId);
   const task = {
     id: randomUUID(),
     boardId: data.boardId,
@@ -17,18 +18,23 @@ export function createTask(data) {
   return taskRepository.create(task);
 }
 
-export function updateTask(id, patch) {
+export function updateTask(id, patch, userId) {
+  const task = taskRepository.findById(id);
+  if (!task) throw new NotFoundError("Task");
+  assertMember(task.boardId, userId);
   const updated = taskRepository.update(id, patch);
-  if (!updated) throw new NotFoundError("Task");
   return updated;
 }
 
-export function deleteTask(id) {
-  const removed = taskRepository.remove(id);
-  if (!removed) throw new NotFoundError("Task");
+export function deleteTask(id, userId) {
+  const task = taskRepository.findById(id);
+  if (!task) throw new NotFoundError("Task");
+  assertMember(task.boardId, userId);
+  taskRepository.remove(id);
 }
 
-export function listTasks(boardId, query = {}) {
+export function listTasks(boardId, userId, query = {}) {
+  assertMember(boardId, userId);
   let tasks = taskRepository.findByBoard(boardId);
 
   // filters


### PR DESCRIPTION
Closes #46

  ## Summary
  - Add board membership check (assertMember) in service layer — 403 if not a member, 404 if board missing
  - Enforce ownership on GET /boards/:id/tasks, POST /tasks, PATCH/DELETE /tasks/:id
  - Add express-rate-limit on /api/auth/login (5 req/min per IP → 429)

  ## Test plan
  - [ ] User B gets 403 when accessing User A's board/tasks
  - [ ] User B gets 403 when creating/updating/deleting tasks on User A's board
  - [ ] >5 rapid login attempts return 429