### PR TITLE
feat: custom due-date calendar for create-task form

### DIFF
--- a/client/src/components/DueDateCalendar.jsx
+++ b/client/src/components/DueDateCalendar.jsx
@@ -1,0 +1,118 @@
+import { useState } from "react";
+
+const WEEKDAYS = ["S", "M", "T", "W", "T", "F", "S"];
+
+function toDateStr(year, month, day) {
+  const m = String(month + 1).padStart(2, "0");
+  const d = String(day).padStart(2, "0");
+  return `${year}-${m}-${d}`;
+}
+
+export default function DueDateCalendar({ value, onChange, taskByDate }) {
+  const initial = value ? new Date(value) : new Date();
+  const [viewYear, setViewYear] = useState(initial.getFullYear());
+  const [viewMonth, setViewMonth] = useState(initial.getMonth());
+
+  const firstDayOfMonth = new Date(viewYear, viewMonth, 1).getDay();
+  const daysInMonth = new Date(viewYear, viewMonth + 1, 0).getDate();
+
+  function goToPrevMonth() {
+    if (viewMonth === 0) {
+      setViewMonth(11);
+      setViewYear(viewYear - 1);
+    } else {
+      setViewMonth(viewMonth - 1);
+    }
+  }
+
+  function goToNextMonth() {
+    if (viewMonth === 11) {
+      setViewMonth(0);
+      setViewYear(viewYear + 1);
+    } else {
+      setViewMonth(viewMonth + 1);
+    }
+  }
+
+  const cells = [];
+  for (let i = 0; i < firstDayOfMonth; i++) {
+    cells.push(null);
+  }
+  for (let day = 1; day <= daysInMonth; day++) {
+    cells.push(day);
+  }
+
+  return (
+    <div className="due-date-calendar bg-slate-950 border border-slate-800 rounded-xl p-4">
+      <div className="due-date-calendar-header flex items-center justify-between mb-3">
+        <button
+          type="button"
+          onClick={goToPrevMonth}
+          className="w-7 h-7 flex items-center justify-center rounded-lg text-slate-400 hover:text-slate-100 hover:bg-slate-800 transition-colors"
+        >
+          &lt;
+        </button>
+        <span className="text-sm font-medium text-slate-200">
+          {new Date(viewYear, viewMonth).toLocaleDateString("en-US", {
+            month: "long",
+            year: "numeric",
+          })}
+        </span>
+        <button
+          type="button"
+          onClick={goToNextMonth}
+          className="w-7 h-7 flex items-center justify-center rounded-lg text-slate-400 hover:text-slate-100 hover:bg-slate-800 transition-colors"
+        >
+          &gt;
+        </button>
+      </div>
+
+      <div className="due-date-calendar-grid grid grid-cols-7 gap-1">
+        {WEEKDAYS.map((wd, i) => (
+          <div
+            key={i}
+            className="due-date-calendar-weekday text-xs font-medium text-slate-500 text-center py-1"
+          >
+            {wd}
+          </div>
+        ))}
+
+        {cells.map((day, i) => {
+          if (day === null) {
+            return <div key={i} className="due-date-calendar-cell empty" />;
+          }
+
+          const dateStr = toDateStr(viewYear, viewMonth, day);
+          const tasksOnDay = taskByDate[dateStr] || [];
+          const isMarked = tasksOnDay.length > 0;
+          const isSelected = dateStr === value;
+
+          const tooltip = isMarked
+            ? tasksOnDay.map((t) => `${t.title} (${t.assignee})`).join(", ")
+            : undefined;
+
+          return (
+            <button
+              key={i}
+              type="button"
+              title={tooltip}
+              onClick={() => onChange(dateStr)}
+              className={`due-date-calendar-cell relative aspect-square flex items-center justify-center text-sm rounded-lg transition-colors ${
+                isSelected
+                  ? "marked selected bg-indigo-500 text-white font-semibold"
+                  : isMarked
+                    ? "marked text-indigo-300 hover:bg-slate-800"
+                    : "text-slate-300 hover:bg-slate-800"
+              }`}
+            >
+              {day}
+              {isMarked && !isSelected && (
+                <span className="absolute bottom-1 w-1 h-1 rounded-full bg-indigo-400" />
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/DueDateCalendar.jsx
+++ b/client/src/components/DueDateCalendar.jsx
@@ -12,6 +12,7 @@ export default function DueDateCalendar({ value, onChange, taskByDate }) {
   const initial = value ? new Date(value) : new Date();
   const [viewYear, setViewYear] = useState(initial.getFullYear());
   const [viewMonth, setViewMonth] = useState(initial.getMonth());
+  const todayStr = new Date().toLocaleDateString("en-CA"); // local YYYY-MM-DD
 
   const firstDayOfMonth = new Date(viewYear, viewMonth, 1).getDay();
   const daysInMonth = new Date(viewYear, viewMonth + 1, 0).getDate();
@@ -86,6 +87,7 @@ export default function DueDateCalendar({ value, onChange, taskByDate }) {
           const tasksOnDay = taskByDate[dateStr] || [];
           const isMarked = tasksOnDay.length > 0;
           const isSelected = dateStr === value;
+          const isPast = dateStr < todayStr;
 
           const tooltip = isMarked
             ? tasksOnDay.map((t) => `${t.title} (${t.assignee})`).join(", ")
@@ -95,18 +97,21 @@ export default function DueDateCalendar({ value, onChange, taskByDate }) {
             <button
               key={i}
               type="button"
+              disabled={isPast}
               title={tooltip}
               onClick={() => onChange(dateStr)}
               className={`due-date-calendar-cell relative aspect-square flex items-center justify-center text-sm rounded-lg transition-colors ${
-                isSelected
-                  ? "marked selected bg-indigo-500 text-white font-semibold"
-                  : isMarked
-                    ? "marked text-indigo-300 hover:bg-slate-800"
-                    : "text-slate-300 hover:bg-slate-800"
+                isPast
+                  ? "text-slate-700 cursor-not-allowed"
+                  : isSelected
+                    ? "marked selected bg-indigo-500 text-white font-semibold"
+                    : isMarked
+                      ? "marked text-indigo-300 hover:bg-slate-800"
+                      : "text-slate-300 hover:bg-slate-800"
               }`}
             >
               {day}
-              {isMarked && !isSelected && (
+              {isMarked && !isSelected && !isPast && (
                 <span className="absolute bottom-1 w-1 h-1 rounded-full bg-indigo-400" />
               )}
             </button>

--- a/client/src/pages/NewTaskPage.jsx
+++ b/client/src/pages/NewTaskPage.jsx
@@ -3,9 +3,10 @@ import { useNavigate } from "react-router-dom";
 import { createTask } from "../api/tasks";
 import { useTasks } from "../hooks/useTasks";
 import Button from "../components/Button";
+import DueDateCalendar from "../components/DueDateCalendar";
 
 export default function NewTaskPage() {
-  const { dispatch, boardId } = useTasks();
+  const { tasks, dispatch, boardId } = useTasks();
   const navigate = useNavigate();
 
   const [title, setTitle] = useState("");
@@ -27,6 +28,12 @@ export default function NewTaskPage() {
     }
     return next;
   }
+
+  const taskByDate = tasks.reduce((acc, task) => {
+    if (!acc[task.dueDate]) acc[task.dueDate] = [];
+    acc[task.dueDate].push(task);
+    return acc;
+  }, {});
 
   async function handleSubmit(e) {
     e.preventDefault();
@@ -103,23 +110,13 @@ export default function NewTaskPage() {
 
           {/* Due Date Input */}
           <div>
-            <label
-              htmlFor="dueDate"
-              className="block text-sm font-medium text-slate-300 mb-1.5"
-            >
+            <label className="block text-sm font-medium text-slate-300 mb-1.5">
               Due date
             </label>
-            <input
-              id="dueDate"
-              type="date"
-              min={today}
+            <DueDateCalendar
               value={dueDate}
-              onChange={(e) => setDueDate(e.target.value)}
-              className={`w-full bg-slate-950 border ${
-                errors.dueDate
-                  ? "border-red-500/50 focus:border-red-500"
-                  : "border-slate-800 focus:border-indigo-500"
-              } rounded-xl px-4 py-2.5 text-sm text-slate-100 focus:outline-none transition-colors`}
+              onChange={setDueDate}
+              taskByDate={taskByDate}
             />
             {errors.dueDate && (
               <p role="alert" className="text-red-400 text-xs mt-1.5">

--- a/client/src/pages/NewTaskPage.jsx
+++ b/client/src/pages/NewTaskPage.jsx
@@ -30,8 +30,9 @@ export default function NewTaskPage() {
   }
 
   const taskByDate = tasks.reduce((acc, task) => {
-    if (!acc[task.dueDate]) acc[task.dueDate] = [];
-    acc[task.dueDate].push(task);
+    if (!task.dueDate) return acc; 
+    const key = task.dueDate.slice(0, 10); // "YYYY-MM-DD" from a string or a Date's ISO
+    (acc[key] ||= []).push(task);
     return acc;
   }, {});
 


### PR DESCRIPTION
## Summary
- Replace the native `<input type="date">` on the New Task form with a custom `DueDateCalendar` component
- Days that already have a task due are visually marked with a dot, with a hover tooltip listing title + assignee
- Selection stays purely visual/informational — doesn't restrict which date can be picked
- Existing required / not-in-the-past validation is unchanged

Closes #14

## Test plan
- [x] `npm run build` in `client/` succeeds
- [x] Manually verified marked days show tooltip and selecting a day still updates the form's due date