### PR TITLE
feat(server): seed a default board on register

### DIFF
--- a/server/src/services/auth.service.js
+++ b/server/src/services/auth.service.js
@@ -3,6 +3,7 @@ import jwt from "jsonwebtoken";
 import { config } from "../config.js";
 import { AppError } from "../utils/AppError.js";
 import { userRepository } from "../repositories/user.repo.js";
+import { createBoard } from "./board.service.js";
 
 const SALT_ROUNDS = 10;
 const TOKEN_EXPIRY = "1h";
@@ -21,6 +22,8 @@ export async function register({ name, email, password }) {
 
   const passwordHash = await bcrypt.hash(password, SALT_ROUNDS);
   const user = userRepository.create({ email, passwordHash, name });
+
+  createBoard(user.id, { name: "My Board" });
 
   return publicUser(user);
 }


### PR DESCRIPTION
## Summary
- `auth.service.register()` now calls `createBoard(user.id, { name: "My Board" })` right after the user is created, so a new user doesn't land on an empty board list

Closes #59

## Test plan
- [x] Registered a fresh user via `POST /api/auth/register`
- [x] Logged in and called `GET /api/boards` — confirmed it returns one board named "My Board"