### PR TITLE
feat(server): Mongoose models - User, Board, Task

### DIFF
--- a/server/src/constants/enums.js
+++ b/server/src/constants/enums.js
@@ -1,0 +1,3 @@
+export const TASK_STATUSES = ["todo", "doing", "done"];
+export const TASK_PRIORITIES = ["low", "normal", "high"];
+export const MEMBER_ROLES = ["owner", "editor", "viewer"];

--- a/server/src/models/board.model.js
+++ b/server/src/models/board.model.js
@@ -4,7 +4,11 @@ import { MEMBER_ROLES } from "../constants/enums.js";
 
 const memberSchema = new mongoose.Schema(
   {
-    userId: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+    },
     role: { type: String, enum: MEMBER_ROLES, default: "viewer" },
   },
   { _id: false },
@@ -13,7 +17,11 @@ const memberSchema = new mongoose.Schema(
 const boardSchema = new mongoose.Schema(
   {
     name: { type: String, required: true, trim: true },
-    ownerId: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
+    ownerId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+    },
     members: { type: [memberSchema], default: [] },
   },
   baseOptions,

--- a/server/src/models/board.model.js
+++ b/server/src/models/board.model.js
@@ -1,0 +1,22 @@
+import mongoose from "mongoose";
+import { baseOptions } from "./model.options.js";
+import { MEMBER_ROLES } from "../constants/enums.js";
+
+const memberSchema = new mongoose.Schema(
+  {
+    userId: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
+    role: { type: String, enum: MEMBER_ROLES, default: "viewer" },
+  },
+  { _id: false },
+);
+
+const boardSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true, trim: true },
+    ownerId: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
+    members: { type: [memberSchema], default: [] },
+  },
+  baseOptions,
+);
+
+export const Board = mongoose.model("Board", boardSchema);

--- a/server/src/models/model.options.js
+++ b/server/src/models/model.options.js
@@ -1,0 +1,11 @@
+export function toIdJSON(doc, ret) {
+  ret.id = ret._id?.toString();
+  delete ret._id;
+  delete ret.__v;
+  return ret;
+}
+
+export const baseOptions = {
+  timestamps: true,
+  toJSON: { transform: toIdJSON },
+};

--- a/server/src/models/task.model.js
+++ b/server/src/models/task.model.js
@@ -1,0 +1,24 @@
+import mongoose from "mongoose";
+import { baseOptions } from "./model.options.js";
+import { TASK_STATUSES, TASK_PRIORITIES } from "../constants/enums.js";
+
+const taskSchema = new mongoose.Schema(
+  {
+    boardId: { type: mongoose.Schema.Types.ObjectId, ref: "Board", required: true },
+    title: { type: String, required: true, trim: true, minlength: 3 },
+    description: { type: String, trim: true, default: "" },
+    status: { type: String, enum: TASK_STATUSES, default: "todo" },
+    // Free-text display name, not a ref: the client sends "Unassigned".
+    assignee: { type: String, trim: true, default: "Unassigned" },
+    dueDate: { type: Date, default: null },
+    priority: { type: String, enum: TASK_PRIORITIES, default: "normal" },
+    position: { type: Number, default: 0 },
+    columnId: { type: String, default: null },
+    // Bumped by the update path in #75. Distinct from Mongoose's own __v,
+    // which is not incremented on ordinary field updates.
+    version: { type: Number, default: 0 },
+  },
+  baseOptions,
+);
+
+export const Task = mongoose.model("Task", taskSchema);

--- a/server/src/models/task.model.js
+++ b/server/src/models/task.model.js
@@ -4,7 +4,11 @@ import { TASK_STATUSES, TASK_PRIORITIES } from "../constants/enums.js";
 
 const taskSchema = new mongoose.Schema(
   {
-    boardId: { type: mongoose.Schema.Types.ObjectId, ref: "Board", required: true },
+    boardId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Board",
+      required: true,
+    },
     title: { type: String, required: true, trim: true, minlength: 3 },
     description: { type: String, trim: true, default: "" },
     status: { type: String, enum: TASK_STATUSES, default: "todo" },

--- a/server/src/models/user.model.js
+++ b/server/src/models/user.model.js
@@ -1,0 +1,23 @@
+import mongoose from "mongoose";
+import { baseOptions, toIdJSON } from "./model.options.js";
+
+const userSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true, trim: true, minlength: 2 },
+    
+    email: { type: String, required: true, trim: true, lowercase: true },
+    passwordHash: { type: String, required: true },
+  },
+  {
+    ...baseOptions,
+    toJSON: {
+      transform(doc, ret) {
+        toIdJSON(doc, ret);
+        delete ret.passwordHash;
+        return ret;
+      },
+    },
+  },
+);
+
+export const User = mongoose.model("User", userSchema);

--- a/server/src/models/user.model.js
+++ b/server/src/models/user.model.js
@@ -4,7 +4,7 @@ import { baseOptions, toIdJSON } from "./model.options.js";
 const userSchema = new mongoose.Schema(
   {
     name: { type: String, required: true, trim: true, minlength: 2 },
-    
+
     email: { type: String, required: true, trim: true, lowercase: true },
     passwordHash: { type: String, required: true },
   },

--- a/server/src/schemas/task.schema.js
+++ b/server/src/schemas/task.schema.js
@@ -1,7 +1,8 @@
 import { z } from "zod";
+import { TASK_STATUSES, TASK_PRIORITIES } from "../constants/enums.js";
 
-const statusEnum = z.enum(["todo", "doing", "done"]);
-const priorityEnum = z.enum(["low", "normal", "high"]);
+const statusEnum = z.enum(TASK_STATUSES);
+const priorityEnum = z.enum(TASK_PRIORITIES);
 
 // optional
 const dueDate = z


### PR DESCRIPTION
Closes #70

Declares the Mongoose schemas for User, Board and Task. **Models only** - no repository or service is wired up to them yet, so API behaviour is unchanged by this PR.

## What's here

- `src/constants/enums.js` - single source of truth for status, priority and member-role values, consumed by both the Mongoose models and the existing Zod schemas so the two can't drift.
- `src/models/model.options.js` - shared `timestamps: true` and the `_id -> id` / `__v` strip, so all three models serialise consistently without repeating it.
- `src/models/user.model.js` - plus a `toJSON` transform that removes `passwordHash` on every serialisation.
- `src/models/board.model.js` - `members: [{ userId, role }]` embedded; tasks referenced separately by `boardId`.
- `src/models/task.model.js` - existing API field names kept so the Postman collection still passes, plus `description`, `position`, `columnId` and `version` (Number, default 0).
- `src/schemas/task.schema.js` - 4-line change: consumes the shared enum arrays instead of its own copies.

## Design decisions worth reviewing

- **Board embeds members, Task is referenced.** Members are only ever read with their board, so embedding avoids a join on every fetch. Tasks are filtered, sorted and paginated independently and have no natural size ceiling, so they get their own collection keyed by `boardId`.
- **`assignee` stays a `String`, not an ObjectId ref.** The client sends a display name and literally sends `"Unassigned"` (`NewTaskPage.jsx:49`), and builds its filter dropdown from the raw values (`Board.jsx:52`). A ref would CastError on every task create.
- **`dueDate` becomes a real `Date`** instead of an ISO string, so range queries and chronological sorting work - needed by #74's overdue aggregation.
- **`role` defaults to `viewer`**, the weakest role, so a missing field can never silently grant write access.

## Deliberately not included

- **No indexes, no `unique: true` on email** - that's #72, kept out so we don't edit the same lines.
- **`publicUser` is still in `auth.service.js`.** `toJSON` only runs on Mongoose documents, and `user.repo.js` still returns plain objects until #71. Removing the manual stripping before then would leak `passwordHash` in the register and login responses. Suggest #71 deletes it in the same PR that swaps the repo over.
- **Activity model skipped** - it's in the issue title but has no fields specified in the body, and no other M3 issue references it. Happy to add it if @dwainXDL can spec the shape.

## Note for #71

`members` changes shape from `[userId]` to `[{ userId, role }]`, so `board.service.js:8` needs updating:

```js
// before - always false against objects, so every board request 403s
if (!board.members.includes(userId)) throw new ForbiddenError();
// after
if (!board.members.some((m) => m.userId.equals(userId))) throw new ForbiddenError();
```

## Note for #75

`Task.version` is a plain Number defaulting to 0, deliberately separate from Mongoose's `__v` (which isn't incremented on ordinary field updates and so can't back optimistic concurrency).

## Verification

All three models compile, carry `createdAt`/`updatedAt`, and `version` defaults to 0. Zod still applies its defaults and rejects invalid enum values after the swap to shared constants. Server boots unchanged.
