### PR TITLE
feat: rewrite repositories against Mongoose

### DIFF
--- a/server/src/controllers/board.controller.js
+++ b/server/src/controllers/board.controller.js
@@ -2,10 +2,10 @@ import { asyncHandler } from "../utils/asyncHandler.js";
 import * as boardService from "../services/board.service.js";
 
 export const create = asyncHandler(async (req, res) => {
-  const board = boardService.createBoard(req.user.id, req.body);
+  const board = await boardService.createBoard(req.user.id, req.body);
   res.status(201).json(board);
 });
 
 export const list = asyncHandler(async (req, res) => {
-  res.json(boardService.listBoardsForUser(req.user.id));
+  res.json(await boardService.listBoardsForUser(req.user.id));
 });

--- a/server/src/controllers/task.controller.js
+++ b/server/src/controllers/task.controller.js
@@ -2,22 +2,22 @@ import { asyncHandler } from "../utils/asyncHandler.js";
 import * as taskService from "../services/task.service.js";
 
 export const create = asyncHandler(async (req, res) => {
-  const task = taskService.createTask(req.body, req.user.id);
+  const task = await taskService.createTask(req.body, req.user.id);
   res.status(201).json(task);
 });
 
 export const update = asyncHandler(async (req, res) => {
-  const task = taskService.updateTask(req.params.id, req.body, req.user.id);
+  const task = await taskService.updateTask(req.params.id, req.body, req.user.id);
   res.status(200).json(task);
 });
 
 export const remove = asyncHandler(async (req, res) => {
-  taskService.deleteTask(req.params.id, req.user.id);
+  await taskService.deleteTask(req.params.id, req.user.id);
   res.status(204).send();
 });
 
 // GET /api/boards/:id/tasks  (id = boardId)
 export const listByBoard = asyncHandler(async (req, res) => {
-  const tasks = taskService.listTasks(req.params.id, req.user.id, req.query);
+  const tasks = await taskService.listTasks(req.params.id, req.user.id, req.query);
   res.status(200).json(tasks);
 });

--- a/server/src/repositories/board.repo.js
+++ b/server/src/repositories/board.repo.js
@@ -1,10 +1,7 @@
-const boards = [];
+import { Board } from "../models/board.model.js";
 
-export const createBoard = (board) => {
-  boards.push(board);
-  return board;
-};
+export const createBoard = (data) => Board.create(data);
 
-export const findById = (id) => boards.find((b) => b.id === id) ?? null;
+export const findById = (id) => Board.findById(id);
 
-export const listBoards = () => boards;
+export const listBoards = () => Board.find();

--- a/server/src/repositories/task.repo.js
+++ b/server/src/repositories/task.repo.js
@@ -1,32 +1,24 @@
-// In-memory store (M2 stage - swapped for Mongoose in M3).
-const tasks = [];
+import { Task } from "../models/task.model.js";
 
 export const taskRepository = {
   findByBoard(boardId) {
-    return tasks.filter((t) => t.boardId === boardId);
+    return Task.find({ boardId });
   },
 
   findById(id) {
-    return tasks.find((t) => t.id === id) ?? null;
+    return Task.findById(id);
   },
 
-  // receives a fully-formed task
-  create(task) {
-    tasks.push(task);
-    return task;
+  create(data) {
+    return Task.create(data);
   },
 
   update(id, patch) {
-    const task = tasks.find((t) => t.id === id);
-    if (!task) return null;
-    Object.assign(task, patch);
-    return task;
+    return Task.findByIdAndUpdate(id, patch, { new: true });
   },
 
-  remove(id) {
-    const index = tasks.findIndex((t) => t.id === id);
-    if (index === -1) return false;
-    tasks.splice(index, 1);
-    return true;
+  async remove(id) {
+    const result = await Task.findByIdAndDelete(id);
+    return !!result;
   },
 };

--- a/server/src/repositories/task.repo.js
+++ b/server/src/repositories/task.repo.js
@@ -14,7 +14,7 @@ export const taskRepository = {
   },
 
   update(id, patch) {
-    return Task.findByIdAndUpdate(id, patch, { new: true });
+    return Task.findByIdAndUpdate(id, patch, { new: true, runValidators: true });
   },
 
   async remove(id) {

--- a/server/src/repositories/user.repo.js
+++ b/server/src/repositories/user.repo.js
@@ -1,23 +1,11 @@
-import { randomUUID } from "node:crypto";
-
-// In-memory store (M2 stage - no DB driver wired up yet).
-// email -> user record: { id, name, email, passwordHash, createdAt }
-const usersByEmail = new Map();
+import { User } from "../models/user.model.js";
 
 export const userRepository = {
-  findByEmail(email) {
-    return usersByEmail.get(email) ?? null;
+  async findByEmail(email) {
+    return User.findOne({ email });
   },
 
-  create({ email, passwordHash, name }) {
-    const user = {
-      id: randomUUID(),
-      name,
-      email,
-      passwordHash,
-      createdAt: new Date().toISOString(),
-    };
-    usersByEmail.set(email, user);
-    return user;
+  async create({ email, passwordHash, name }) {
+    return User.create({ name, email, passwordHash });
   },
 };

--- a/server/src/services/auth.service.js
+++ b/server/src/services/auth.service.js
@@ -8,28 +8,22 @@ import { createBoard } from "./board.service.js";
 const SALT_ROUNDS = 10;
 const TOKEN_EXPIRY = "1h";
 
-// Strips sensitive fields (passwordHash) before a user object leaves the service.
-export function publicUser(user) {
-  const { passwordHash, ...safe } = user;
-  return safe;
-}
-
 export async function register({ name, email, password }) {
-  const existing = userRepository.findByEmail(email);
+  const existing = await userRepository.findByEmail(email);
   if (existing) {
     throw new AppError("Email already in use", 409, "EMAIL_IN_USE");
   }
 
   const passwordHash = await bcrypt.hash(password, SALT_ROUNDS);
-  const user = userRepository.create({ email, passwordHash, name });
+  const user = await userRepository.create({ email, passwordHash, name });
 
-  createBoard(user.id, { name: "My Board" });
+  await createBoard(user.id, { name: "My Board" });
 
-  return publicUser(user);
+  return user;
 }
 
 export async function login({ email, password }) {
-  const user = userRepository.findByEmail(email);
+  const user = await userRepository.findByEmail(email);
   if (!user) {
     throw new AppError("Invalid Email or Password", 401, "INVALID_CREDENTIALS");
   }
@@ -42,14 +36,12 @@ export async function login({ email, password }) {
   const token = jwt.sign(
     { sub: user.id, email: user.email, name: user.name },
     config.jwtSecret,
-    {
-      expiresIn: TOKEN_EXPIRY,
-    },
+    { expiresIn: TOKEN_EXPIRY },
   );
 
-  return { token, user: publicUser(user) };
+  return { token, user };
 }
 
 export function me(user) {
-  return publicUser(user);
+  return user;
 }

--- a/server/src/services/board.service.js
+++ b/server/src/services/board.service.js
@@ -1,25 +1,23 @@
-import { randomUUID } from "node:crypto";
 import * as boardRepo from "../repositories/board.repo.js";
 import { NotFoundError, ForbiddenError } from "../utils/AppError.js";
 
-export function assertMember(boardId, userId) {
-  const board = boardRepo.findById(boardId);
+export async function assertMember(boardId, userId) {
+  const board = await boardRepo.findById(boardId);
   if (!board) throw new NotFoundError("Board");
-  if (!board.members.includes(userId)) throw new ForbiddenError();
+  if (!board.members.some((m) => m.userId.equals(userId)))
+    throw new ForbiddenError();
   return board;
 }
 
-export function createBoard(userId, { name }) {
-  const board = {
-    id: randomUUID(),
+export async function createBoard(userId, { name }) {
+  return boardRepo.createBoard({
     name,
     ownerId: userId,
-    members: [userId],
-  };
-
-  return boardRepo.createBoard(board);
+    members: [{ userId, role: "owner" }],
+  });
 }
 
-export function listBoardsForUser(userId) {
-  return boardRepo.listBoards().filter((b) => b.members.includes(userId));
+export async function listBoardsForUser(userId) {
+  const boards = await boardRepo.listBoards();
+  return boards.filter((b) => b.members.some((m) => m.userId.equals(userId)));
 }

--- a/server/src/services/task.service.js
+++ b/server/src/services/task.service.js
@@ -1,48 +1,42 @@
-import { randomUUID } from "node:crypto";
 import { taskRepository } from "../repositories/task.repo.js";
 import { NotFoundError } from "../utils/AppError.js";
 import { assertMember } from "./board.service.js";
 
-export function createTask(data, userId) {
-  assertMember(data.boardId, userId);
-  const task = {
-    id: randomUUID(),
+export async function createTask(data, userId) {
+  await assertMember(data.boardId, userId);
+  return taskRepository.create({
     boardId: data.boardId,
     title: data.title,
-    status: data.status, // zod defaults to "todo"
+    status: data.status,
     assignee: data.assignee ?? null,
     dueDate: data.dueDate ?? null,
-    priority: data.priority, // zod defaults to "normal"
-    createdAt: new Date().toISOString(),
-  };
-  return taskRepository.create(task);
+    priority: data.priority,
+  });
 }
 
-export function updateTask(id, patch, userId) {
-  const task = taskRepository.findById(id);
+export async function updateTask(id, patch, userId) {
+  const task = await taskRepository.findById(id);
   if (!task) throw new NotFoundError("Task");
-  assertMember(task.boardId, userId);
-  const updated = taskRepository.update(id, patch);
+  await assertMember(task.boardId, userId);
+  const updated = await taskRepository.update(id, patch);
   return updated;
 }
 
-export function deleteTask(id, userId) {
-  const task = taskRepository.findById(id);
+export async function deleteTask(id, userId) {
+  const task = await taskRepository.findById(id);
   if (!task) throw new NotFoundError("Task");
-  assertMember(task.boardId, userId);
-  taskRepository.remove(id);
+  await assertMember(task.boardId, userId);
+  await taskRepository.remove(id);
 }
 
-export function listTasks(boardId, userId, query = {}) {
-  assertMember(boardId, userId);
-  let tasks = taskRepository.findByBoard(boardId);
+export async function listTasks(boardId, userId, query = {}) {
+  await assertMember(boardId, userId);
+  let tasks = await taskRepository.findByBoard(boardId);
 
-  // filters
   if (query.status) tasks = tasks.filter((t) => t.status === query.status);
   if (query.assignee)
     tasks = tasks.filter((t) => t.assignee === query.assignee);
 
-  // sort: ?sort=field (asc) or ?sort=-field (desc)
   if (query.sort) {
     const desc = query.sort.startsWith("-");
     const key = desc ? query.sort.slice(1) : query.sort;
@@ -54,7 +48,6 @@ export function listTasks(boardId, userId, query = {}) {
     });
   }
 
-  // pagination: only when ?limit= is provided
   if (query.limit) {
     const limit = Math.max(1, Number(query.limit) || 1);
     const page = Math.max(1, Number(query.page) || 1);

--- a/server/src/services/task.service.js
+++ b/server/src/services/task.service.js
@@ -8,7 +8,7 @@ export async function createTask(data, userId) {
     boardId: data.boardId,
     title: data.title,
     status: data.status,
-    assignee: data.assignee ?? null,
+    assignee: data.assignee,
     dueDate: data.dueDate ?? null,
     priority: data.priority,
   });


### PR DESCRIPTION
Closes #71

  ## Summary
  - Rewrite user/board/task repos to use Mongoose models, delete in-memory arrays
  - Add await to all service and controller calls (repos are now async)
  - Fix members shape to [{userId, role}] and use .equals() for membership checks
  - Remove publicUser() from auth.service (User model toJSON handles it)

  ## Test plan
  - [x] Register creates user + default board in MongoDB
  - [x] Login returns valid JWT
  - [x] Create/list tasks works through Mongoose
  - [x] Data persists after server restart