### PR TITLE
feat: PouchDB local store + render from local cache

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.3",
+        "events": "^3.3.0",
+        "pouchdb-browser": "^8.0.1",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "react-router-dom": "^7.18.2",
@@ -603,9 +605,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -621,9 +620,6 @@
       "integrity": "sha512-B5G/zJdHaoJn9vD50eGHWkiWfmq8Uhi3IiLPJTzmZTrAalk1bztUikSXo0qga18ibE0IXboyeMUnhPjhAJ45wQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -641,9 +637,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -659,9 +652,6 @@
       "integrity": "sha512-412MX9fJLdA1IK28EZnc8jYv2HRTleOZgfLQumJ5zy7OeJLZlg/CETwFaXjNmGVxG51cFHpKLqb5LKvBC+HsHA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -679,9 +669,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -697,9 +684,6 @@
       "integrity": "sha512-ZKp/w41n6wCvxzxQHtQSbuphfX3Y4cCvbjkKHusrLx4lh+JWLTU7StSltO/DKARISzbj368d+qUaCjI8K2wzXw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -915,9 +899,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -937,9 +918,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -961,9 +939,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -983,9 +958,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -1150,9 +1122,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1168,9 +1137,6 @@
       "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1188,9 +1154,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1206,9 +1169,6 @@
       "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1812,6 +1772,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1983,6 +1952,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
+      "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==",
+      "license": "MIT"
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
@@ -2247,9 +2222,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2269,9 +2241,6 @@
       "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -2293,9 +2262,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2315,9 +2281,6 @@
       "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -2581,6 +2544,18 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pouchdb-browser": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/pouchdb-browser/-/pouchdb-browser-8.0.1.tgz",
+      "integrity": "sha512-wXObS1Layd/gBRKwa6EBS99tFY9G3VPaMRu8ffWCohkpi9PZCm3z1xeB4P4S9Qecf0u5so+rxvbVVyTtgdhvaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "immediate": "3.3.0",
+        "spark-md5": "3.0.2",
+        "uuid": "8.3.2",
+        "vuvuzela": "1.0.3"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -2762,6 +2737,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/spark-md5": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
+      "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==",
+      "license": "(WTFPL OR MIT)"
+    },
     "node_modules/tailwindcss": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
@@ -2851,6 +2832,16 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/vite": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.0.tgz",
@@ -2927,6 +2918,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vuvuzela": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/vuvuzela/-/vuvuzela-1.0.3.tgz",
+      "integrity": "sha512-Tm7jR1xTzBbPW+6y1tknKiEhz04Wf/1iZkcTJjSFcpNko43+dFW6+OOeQe9taJIug3NdfUAjFKgUSyQrIKaDvQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,8 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.3.3",
+    "events": "^3.3.0",
+    "pouchdb-browser": "^8.0.1",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-router-dom": "^7.18.2",

--- a/client/src/components/Board.jsx
+++ b/client/src/components/Board.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useTasks } from "../hooks/useTasks";
 import { updateTaskStatus, deleteTask } from "../api/tasks";
+import { putTask, removeTask } from "../db/localDB";
 import Column from "./Column";
 import FilterBar from "./FilterBar";
 import { filterTasks } from "../utils/filterTasks";
@@ -35,6 +36,8 @@ export default function Board() {
     try {
       await updateTaskStatus(id, status);
       dispatch({ type: "moved", id, status });
+      const task = tasks.find((t) => t.id === id);
+      if (task) putTask({ ...task, status });
     } catch (err) {
       setActionError(err.message || "Failed to move task");
     }
@@ -43,6 +46,7 @@ export default function Board() {
     try {
       await deleteTask(id);
       dispatch({ type: "deleted", id });
+      removeTask(id);
     } catch (err) {
       setActionError(err.message || "Failed to delete task");
     }

--- a/client/src/context/BoardProvider.jsx
+++ b/client/src/context/BoardProvider.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { BoardContext } from "./BoardContext";
 import { getBoards } from "../api/boards";
 import { useAuth } from "../hooks/useAuth";
+import { getLocalBoards, putBoards, clearAll } from "../db/localDB";
 
 export function BoardProvider({ children }) {
   const { token } = useAuth();
@@ -11,13 +12,25 @@ export function BoardProvider({ children }) {
   const [error, setError] = useState(null);
 
   const loadBoards = useCallback(() => {
-    setLoading(true);
     setError(null);
 
+    // 1. Read from local cache first (instant render)
+    getLocalBoards()
+      .then((cached) => {
+        if (cached.length > 0) {
+          setBoards(cached);
+          setCurrentBoard((prev) => prev ?? cached[0]);
+          setLoading(false);
+        }
+      })
+      .catch(() => {});
+
+    // 2. Fetch from server and reconcile
     getBoards()
       .then((data) => {
         setBoards(data);
         setCurrentBoard((prev) => prev ?? data[0] ?? null);
+        putBoards(data);
       })
       .catch((err) => {
         setError(err.message || "Failed to load boards");
@@ -32,6 +45,7 @@ export function BoardProvider({ children }) {
       setBoards([]);
       setCurrentBoard(null);
       setLoading(false);
+      clearAll();
     }
   }, [token, loadBoards]);
 

--- a/client/src/context/TasksProvider.jsx
+++ b/client/src/context/TasksProvider.jsx
@@ -2,18 +2,24 @@ import { useReducer, useEffect, useState, useCallback } from "react";
 import { TasksContext } from "./TasksContext";
 import { getTasks } from "../api/tasks";
 import { useBoard } from "../hooks/useBoard";
+import { getLocalTasks, putTasks, putTask, removeTask } from "../db/localDB";
 
 function tasksReducer(state, action) {
   switch (action.type) {
     case "loaded":
       return action.tasks;
     case "added":
+      putTask(action.task);
       return [...state, action.task];
-    case "moved":
+    case "moved": {
+      const updated = state.find((t) => t.id === action.id);
+      if (updated) putTask({ ...updated, status: action.status });
       return state.map((t) =>
         t.id === action.id ? { ...t, status: action.status } : t,
       );
+    }
     case "deleted":
+      removeTask(action.id);
       return state.filter((t) => t.id !== action.id);
     default:
       throw new Error("Unknown action: " + action.type);
@@ -35,12 +41,23 @@ export function TasksProvider({ children }) {
       return;
     }
 
-    setLoading(true);
     setError(null);
 
+    // 1. Read from local cache first (instant render)
+    getLocalTasks(boardId)
+      .then((cached) => {
+        if (cached.length > 0) {
+          dispatch({ type: "loaded", tasks: cached });
+          setLoading(false);
+        }
+      })
+      .catch(() => {});
+
+    // 2. Fetch from server and reconcile
     getTasks(boardId)
       .then((data) => {
         dispatch({ type: "loaded", tasks: data });
+        putTasks(data);
       })
       .catch((err) => {
         setError(err.message || "Failed to load tasks");

--- a/client/src/context/TasksProvider.jsx
+++ b/client/src/context/TasksProvider.jsx
@@ -2,24 +2,19 @@ import { useReducer, useEffect, useState, useCallback } from "react";
 import { TasksContext } from "./TasksContext";
 import { getTasks } from "../api/tasks";
 import { useBoard } from "../hooks/useBoard";
-import { getLocalTasks, putTasks, putTask, removeTask } from "../db/localDB";
+import { getLocalTasks, putTasks } from "../db/localDB";
 
 function tasksReducer(state, action) {
   switch (action.type) {
     case "loaded":
       return action.tasks;
     case "added":
-      putTask(action.task);
       return [...state, action.task];
-    case "moved": {
-      const updated = state.find((t) => t.id === action.id);
-      if (updated) putTask({ ...updated, status: action.status });
+    case "moved":
       return state.map((t) =>
         t.id === action.id ? { ...t, status: action.status } : t,
       );
-    }
     case "deleted":
-      removeTask(action.id);
       return state.filter((t) => t.id !== action.id);
     default:
       throw new Error("Unknown action: " + action.type);

--- a/client/src/db/localDB.js
+++ b/client/src/db/localDB.js
@@ -1,0 +1,79 @@
+import PouchDB from "pouchdb-browser";
+
+let db = new PouchDB("collabboard");
+
+// --- Boards ---
+
+export async function getLocalBoards() {
+  const result = await db.allDocs({
+    startkey: "board:",
+    endkey: "board:\ufff0",
+    include_docs: true,
+  });
+  return result.rows.map((r) => r.doc.data);
+}
+
+export async function putBoards(boards) {
+  for (const board of boards) {
+    const doc = { _id: `board:${board.id}`, data: board };
+    try {
+      const existing = await db.get(doc._id);
+      doc._rev = existing._rev;
+    } catch {
+      // new doc
+    }
+    await db.put(doc);
+  }
+}
+
+// --- Tasks ---
+
+export async function getLocalTasks(boardId) {
+  const result = await db.allDocs({
+    startkey: "task:",
+    endkey: "task:\ufff0",
+    include_docs: true,
+  });
+  const tasks = result.rows.map((r) => r.doc.data);
+  return boardId ? tasks.filter((t) => t.boardId === boardId) : tasks;
+}
+
+export async function putTasks(tasks) {
+  for (const task of tasks) {
+    const doc = { _id: `task:${task.id}`, data: task };
+    try {
+      const existing = await db.get(doc._id);
+      doc._rev = existing._rev;
+    } catch {
+      // new doc
+    }
+    await db.put(doc);
+  }
+}
+
+export async function putTask(task) {
+  const doc = { _id: `task:${task.id}`, data: task };
+  try {
+    const existing = await db.get(doc._id);
+    doc._rev = existing._rev;
+  } catch {
+    // new doc
+  }
+  await db.put(doc);
+}
+
+export async function removeTask(id) {
+  try {
+    const doc = await db.get(`task:${id}`);
+    await db.remove(doc);
+  } catch {
+    // already deleted or not found
+  }
+}
+
+// --- Cleanup ---
+
+export async function clearAll() {
+  await db.destroy();
+  db = new PouchDB("collabboard");
+}

--- a/client/src/pages/NewTaskPage.jsx
+++ b/client/src/pages/NewTaskPage.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { createTask } from "../api/tasks";
+import { putTask } from "../db/localDB";
 import { useTasks } from "../hooks/useTasks";
 import Button from "../components/Button";
 import DueDateCalendar from "../components/DueDateCalendar";
@@ -51,6 +52,7 @@ export default function NewTaskPage() {
       dueDate,
     });
     dispatch({ type: "added", task });
+    putTask(task);
     navigate("/");
   }
 

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -5,6 +5,9 @@ import tailwindcss from "@tailwindcss/vite";
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  define: { global: "globalThis" },
+  optimizeDeps: { include: ["pouchdb-browser"] },
+  resolve: { alias: { events: "events" } },
   server: {
     proxy: {
       "/api": { target: "http://localhost:4000", changeOrigin: true },


### PR DESCRIPTION
## Summary
  - Add `pouchdb-browser` with prefixed IDs (`board:`, `task:`) for local storage
  - BoardProvider and TasksProvider render instantly from local cache, then reconcile with server in the background
  - Local DB writes on task create/move/delete for offline persistence
  - Local DB cleared on logout to prevent data leaking between users
  - Vite config fixes for PouchDB browser compatibility (`global`, `events` polyfill)

  ## Test plan
  - [ ] Login → create tasks → reload page → board appears instantly from cache (no spinner)
  - [ ] Server changes still sync in after cache render
  - [ ] Move/delete tasks → reload → changes persist locally
  - [ ] Logout → login as different user → no stale data from previous user

  Closes #77