### PR TITLE
feat(server): guard invalid ObjectId with 404 response

### DIFF
--- a/server/src/middleware/errorHandler.js
+++ b/server/src/middleware/errorHandler.js
@@ -6,6 +6,10 @@ export function notFoundHandler(req, res, next) {
 
 // eslint-disable-next-line no-unused-vars
 export function errorHandler(err, req, res, next) {
+  // Mongoose CastError - treat it as a 404
+  if (err.name === "CastError") {
+    err = new AppError("Resource not found", 404, "NOT_FOUND");
+  }
   const status = err.status ?? 500;
   const body = {
     message: status === 500 ? "SOMETHING WENT WRONG..." : err.message,

--- a/server/src/middleware/validateObjectId.js
+++ b/server/src/middleware/validateObjectId.js
@@ -1,0 +1,13 @@
+import mongoose from "mongoose";
+import {AppError}from "../utils/AppError.js";
+
+export const validateObjectId = (req, res, next) => {
+  const { id } = req.params;
+  
+  
+  if (id && !mongoose.Types.ObjectId.isValid(id)) {
+    return next(new AppError("Invalid task ID format", 404));
+  }
+  
+  next();
+};

--- a/server/src/middleware/validateObjectId.js
+++ b/server/src/middleware/validateObjectId.js
@@ -1,13 +1,10 @@
 import mongoose from "mongoose";
-import {AppError}from "../utils/AppError.js";
+import { NotFoundError } from "../utils/AppError.js";
 
 export const validateObjectId = (req, res, next) => {
   const { id } = req.params;
-  
-  
   if (id && !mongoose.Types.ObjectId.isValid(id)) {
-    return next(new AppError("Invalid task ID format", 404));
+    return next(new NotFoundError("Resource"));
   }
-  
   next();
 };

--- a/server/src/routes/board.routes.js
+++ b/server/src/routes/board.routes.js
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { validate } from "../middleware/validate.js";
+import { validateObjectId } from "../middleware/validateObjectId.js";
 import { createBoardSchema } from "../schemas/board.schema.js";
 import * as boards from "../controllers/board.controller.js";
 import * as tasks from "../controllers/task.controller.js";
@@ -10,6 +11,6 @@ router.get("/", boards.list);
 
 router.post("/", validate(createBoardSchema), boards.create);
 
-router.get("/:id/tasks", tasks.listByBoard);
+router.get("/:id/tasks", validateObjectId, tasks.listByBoard);
 
 export default router;

--- a/server/src/routes/task.routes.js
+++ b/server/src/routes/task.routes.js
@@ -1,10 +1,13 @@
 import { Router } from "express";
 import { validate } from "../middleware/validate.js";
+import { validateObjectId } from "../middleware/validateObjectId.js";
 import { createTaskSchema, updateTaskSchema } from "../schemas/task.schema.js";
 import * as tasks from "../controllers/task.controller.js";
 
 const router = Router();
+
 router.post("/", validate(createTaskSchema), tasks.create);
-router.patch("/:id", validate(updateTaskSchema), tasks.update);
-router.delete("/:id", tasks.remove);
+router.patch("/:id", validateObjectId, validate(updateTaskSchema), tasks.update);
+router.delete("/:id", validateObjectId, tasks.remove);
+
 export default router;

--- a/server/src/routes/task.routes.js
+++ b/server/src/routes/task.routes.js
@@ -7,7 +7,12 @@ import * as tasks from "../controllers/task.controller.js";
 const router = Router();
 
 router.post("/", validate(createTaskSchema), tasks.create);
-router.patch("/:id", validateObjectId, validate(updateTaskSchema), tasks.update);
+router.patch(
+  "/:id",
+  validateObjectId,
+  validate(updateTaskSchema),
+  tasks.update,
+);
 router.delete("/:id", validateObjectId, tasks.remove);
 
 export default router;


### PR DESCRIPTION
Added validateObjectId middleware to catch invalid MongoDB ObjectIDs and return a proper 404 response safely without crashing the server.