### PR TITLE
feat: offline support + reconcile

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -30,6 +30,7 @@
     "eslint-plugin-react-refresh": "^0.5.3",
     "globals": "^17.7.0",
     "prettier": "^3.9.6",
-    "vite": "^8.2.0"
+    "vite": "^8.2.0",
+    "vite-plugin-pwa": "^1.3.0"
   }
 }

--- a/client/src/components/Board.jsx
+++ b/client/src/components/Board.jsx
@@ -14,7 +14,7 @@ const COLUMNS = [
 ];
 
 export default function Board() {
-  const { tasks, dispatch } = useTasks();
+  const { tasks, dispatch, offline } = useTasks();
   const [searchParams, setSearchParams] = useSearchParams();
   const [actionError, setActionError] = useState(null);
 
@@ -65,6 +65,12 @@ export default function Board() {
           Manage and track your team tasks efficiently.
         </p>
       </header>
+
+      {offline && (
+        <div className="mb-4 flex items-center gap-2 rounded-lg border border-amber-900 bg-amber-950/50 p-3 text-sm text-amber-400">
+          <span>You are offline. Showing cached data.</span>
+        </div>
+      )}
 
       {actionError && (
         <div className="mb-4 flex items-center justify-between rounded-lg border border-red-900 bg-red-950/50 p-3 text-sm text-red-400">

--- a/client/src/context/BoardProvider.jsx
+++ b/client/src/context/BoardProvider.jsx
@@ -1,8 +1,8 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { BoardContext } from "./BoardContext";
 import { getBoards } from "../api/boards";
 import { useAuth } from "../hooks/useAuth";
-import { getLocalBoards, putBoards, clearAll } from "../db/localDB";
+import { getLocalBoards, reconcileBoards, clearAll } from "../db/localDB";
 
 export function BoardProvider({ children }) {
   const { token } = useAuth();
@@ -10,14 +10,18 @@ export function BoardProvider({ children }) {
   const [currentBoard, setCurrentBoard] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [offline, setOffline] = useState(false);
+  const serverLoaded = useRef(false);
 
   const loadBoards = useCallback(() => {
     setError(null);
+    setOffline(false);
+    serverLoaded.current = false;
 
     // 1. Read from local cache first (instant render)
     getLocalBoards()
       .then((cached) => {
-        if (cached.length > 0) {
+        if (cached.length > 0 && !serverLoaded.current) {
           setBoards(cached);
           setCurrentBoard((prev) => prev ?? cached[0]);
           setLoading(false);
@@ -28,12 +32,27 @@ export function BoardProvider({ children }) {
     // 2. Fetch from server and reconcile
     getBoards()
       .then((data) => {
+        serverLoaded.current = true;
         setBoards(data);
         setCurrentBoard((prev) => prev ?? data[0] ?? null);
-        putBoards(data);
+        setOffline(false);
+        reconcileBoards(data);
       })
       .catch((err) => {
-        setError(err.message || "Failed to load boards");
+        if (!serverLoaded.current) {
+          // If cache was rendered, show offline indicator instead of blocking error
+          getLocalBoards()
+            .then((cached) => {
+              if (cached.length > 0) {
+                setOffline(true);
+              } else {
+                setError(err.message || "Failed to load boards");
+              }
+            })
+            .catch(() => {
+              setError(err.message || "Failed to load boards");
+            });
+        }
       })
       .finally(() => setLoading(false));
   }, []);
@@ -45,6 +64,7 @@ export function BoardProvider({ children }) {
       setBoards([]);
       setCurrentBoard(null);
       setLoading(false);
+      setOffline(false);
       clearAll();
     }
   }, [token, loadBoards]);
@@ -55,7 +75,15 @@ export function BoardProvider({ children }) {
 
   return (
     <BoardContext.Provider
-      value={{ boards, currentBoard, setCurrentBoard, loading, error, retry }}
+      value={{
+        boards,
+        currentBoard,
+        setCurrentBoard,
+        loading,
+        error,
+        offline,
+        retry,
+      }}
     >
       {children}
     </BoardContext.Provider>

--- a/client/src/context/TasksProvider.jsx
+++ b/client/src/context/TasksProvider.jsx
@@ -1,8 +1,8 @@
-import { useReducer, useEffect, useState, useCallback } from "react";
+import { useReducer, useEffect, useState, useCallback, useRef } from "react";
 import { TasksContext } from "./TasksContext";
 import { getTasks } from "../api/tasks";
 import { useBoard } from "../hooks/useBoard";
-import { getLocalTasks, putTasks } from "../db/localDB";
+import { getLocalTasks, reconcileTasks } from "../db/localDB";
 
 function tasksReducer(state, action) {
   switch (action.type) {
@@ -26,6 +26,8 @@ export function TasksProvider({ children }) {
   const [tasks, dispatch] = useReducer(tasksReducer, []);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [offline, setOffline] = useState(false);
+  const serverLoaded = useRef(false);
 
   const boardId = currentBoard?.id;
 
@@ -37,11 +39,13 @@ export function TasksProvider({ children }) {
     }
 
     setError(null);
+    setOffline(false);
+    serverLoaded.current = false;
 
     // 1. Read from local cache first (instant render)
     getLocalTasks(boardId)
       .then((cached) => {
-        if (cached.length > 0) {
+        if (cached.length > 0 && !serverLoaded.current) {
           dispatch({ type: "loaded", tasks: cached });
           setLoading(false);
         }
@@ -51,11 +55,25 @@ export function TasksProvider({ children }) {
     // 2. Fetch from server and reconcile
     getTasks(boardId)
       .then((data) => {
+        serverLoaded.current = true;
         dispatch({ type: "loaded", tasks: data });
-        putTasks(data);
+        setOffline(false);
+        reconcileTasks(boardId, data);
       })
       .catch((err) => {
-        setError(err.message || "Failed to load tasks");
+        if (!serverLoaded.current) {
+          getLocalTasks(boardId)
+            .then((cached) => {
+              if (cached.length > 0) {
+                setOffline(true);
+              } else {
+                setError(err.message || "Failed to load tasks");
+              }
+            })
+            .catch(() => {
+              setError(err.message || "Failed to load tasks");
+            });
+        }
       })
       .finally(() => setLoading(false));
   }, [boardId]);
@@ -70,7 +88,7 @@ export function TasksProvider({ children }) {
 
   return (
     <TasksContext.Provider
-      value={{ tasks, dispatch, loading, error, retry, boardId }}
+      value={{ tasks, dispatch, loading, error, offline, retry, boardId }}
     >
       {children}
     </TasksContext.Provider>

--- a/client/src/db/localDB.js
+++ b/client/src/db/localDB.js
@@ -26,6 +26,26 @@ export async function putBoards(boards) {
   }
 }
 
+export async function reconcileBoards(serverBoards) {
+  const serverIds = new Set(serverBoards.map((b) => b.id));
+
+  // Remove local boards not on server
+  const local = await db.allDocs({
+    startkey: "board:",
+    endkey: "board:\ufff0",
+    include_docs: true,
+  });
+  for (const row of local.rows) {
+    const localId = row.doc.data?.id;
+    if (localId && !serverIds.has(localId)) {
+      await db.remove(row.doc);
+    }
+  }
+
+  // Upsert server boards
+  await putBoards(serverBoards);
+}
+
 // --- Tasks ---
 
 export async function getLocalTasks(boardId) {
@@ -49,6 +69,26 @@ export async function putTasks(tasks) {
     }
     await db.put(doc);
   }
+}
+
+export async function reconcileTasks(boardId, serverTasks) {
+  const serverIds = new Set(serverTasks.map((t) => t.id));
+
+  // Remove local tasks for this board not on server
+  const local = await db.allDocs({
+    startkey: "task:",
+    endkey: "task:\ufff0",
+    include_docs: true,
+  });
+  for (const row of local.rows) {
+    const task = row.doc.data;
+    if (task?.boardId === boardId && !serverIds.has(task.id)) {
+      await db.remove(row.doc);
+    }
+  }
+
+  // Upsert server tasks
+  await putTasks(serverTasks);
 }
 
 export async function putTask(task) {

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,10 +1,35 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+import { VitePWA } from "vite-plugin-pwa";
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [
+    react(),
+    tailwindcss(),
+    VitePWA({
+      registerType: "autoUpdate",
+      workbox: {
+        globPatterns: ["**/*.{js,css,html,ico,svg,png,woff2}"],
+      },
+      manifest: {
+        name: "CollabBoard",
+        short_name: "CollabBoard",
+        start_url: "/",
+        display: "standalone",
+        background_color: "#0f172a",
+        theme_color: "#0f172a",
+        icons: [
+          {
+            src: "/favicon.svg",
+            sizes: "any",
+            type: "image/svg+xml",
+          },
+        ],
+      },
+    }),
+  ],
   define: { global: "globalThis" },
   optimizeDeps: { include: ["pouchdb-browser"] },
   resolve: { alias: { events: "events" } },


### PR DESCRIPTION
Part of #78

  ## Summary
  - Add reconcileTasks/reconcileBoards to prune stale cache entries on server fetch
  - Server-wins guard (serverLoaded ref) prevents stale cache from overwriting fresh server data
  - Graceful offline fallback: show cached data with offline banner instead of blocking error
  - PWA app-shell via vite-plugin-pwa for offline reload support

  ## Test plan
  - [x] Deleted task via curl does not reappear from cache after refresh
  - [x] Server offline shows cached data with yellow offline banner
  - [x] Server data overwrites cache when both respond