### PR TITLE
feat: overdue-by-assignee stats panel

### DIFF
--- a/client/src/api/boards.js
+++ b/client/src/api/boards.js
@@ -10,3 +10,7 @@ export function createBoard(data) {
     body: JSON.stringify(data),
   });
 }
+
+export function getBoardStats(boardId) {
+  return request(`/api/boards/${boardId}/stats`);
+}

--- a/client/src/components/Board.jsx
+++ b/client/src/components/Board.jsx
@@ -5,6 +5,7 @@ import { updateTaskStatus, deleteTask } from "../api/tasks";
 import { putTask, removeTask } from "../db/localDB";
 import Column from "./Column";
 import FilterBar from "./FilterBar";
+import OverdueStats from "./OverdueStats";
 import { filterTasks } from "../utils/filterTasks";
 
 const COLUMNS = [
@@ -14,9 +15,10 @@ const COLUMNS = [
 ];
 
 export default function Board() {
-  const { tasks, dispatch, offline } = useTasks();
+  const { tasks, dispatch, offline, boardId } = useTasks();
   const [searchParams, setSearchParams] = useSearchParams();
   const [actionError, setActionError] = useState(null);
+  const [statsKey, setStatsKey] = useState(0);
 
   const filters = {
     status: searchParams.get("status") || "all",
@@ -38,6 +40,7 @@ export default function Board() {
       dispatch({ type: "moved", id, status });
       const task = tasks.find((t) => t.id === id);
       if (task) putTask({ ...task, status });
+      setStatsKey((k) => k + 1);
     } catch (err) {
       setActionError(err.message || "Failed to move task");
     }
@@ -47,6 +50,7 @@ export default function Board() {
       await deleteTask(id);
       dispatch({ type: "deleted", id });
       removeTask(id);
+      setStatsKey((k) => k + 1);
     } catch (err) {
       setActionError(err.message || "Failed to delete task");
     }
@@ -84,6 +88,8 @@ export default function Board() {
           </button>
         </div>
       )}
+
+      <OverdueStats boardId={boardId} refreshKey={statsKey} />
 
       <FilterBar
         filters={filters}

--- a/client/src/components/OverdueStats.jsx
+++ b/client/src/components/OverdueStats.jsx
@@ -1,0 +1,64 @@
+import { useState, useEffect } from "react";
+import { getBoardStats } from "../api/boards";
+
+export default function OverdueStats({ boardId, refreshKey }) {
+  const [stats, setStats] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!boardId) return;
+
+    setLoading(true);
+    setError(null);
+
+    getBoardStats(boardId)
+      .then((data) => {
+        const sorted = [...data].sort((a, b) => b.overdueCount - a.overdueCount);
+        setStats(sorted);
+      })
+      .catch((err) => {
+        setError(err.message || "Failed to load stats");
+      })
+      .finally(() => setLoading(false));
+  }, [boardId, refreshKey]);
+
+  return (
+    <div className="bg-slate-900/50 border border-slate-800 rounded-xl p-4 mb-6">
+      <h3 className="text-sm font-semibold text-slate-300 mb-3">
+        Overdue by Assignee
+      </h3>
+
+      {loading && (
+        <div className="flex items-center gap-2 text-xs text-slate-500">
+          <div className="h-3 w-3 animate-spin rounded-full border-2 border-slate-500 border-t-transparent" />
+          Loading...
+        </div>
+      )}
+
+      {error && (
+        <p className="text-xs text-red-400">{error}</p>
+      )}
+
+      {!loading && !error && stats.length === 0 && (
+        <p className="text-xs text-slate-500">No overdue tasks</p>
+      )}
+
+      {!loading && !error && stats.length > 0 && (
+        <ul className="space-y-1.5">
+          {stats.map((s) => (
+            <li
+              key={s.assignee}
+              className="flex items-center justify-between text-sm"
+            >
+              <span className="text-slate-300">{s.assignee}</span>
+              <span className="bg-red-950 text-red-400 border border-red-900 rounded-md px-2 py-0.5 text-xs font-medium">
+                {s.overdueCount} overdue
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #92

  ## Summary
  - Add getBoardStats(boardId) API call
  - Create OverdueStats component with loading/error/empty/success states
  - Render stats panel on board, refreshes after task move/delete and on board switch

  ## Test plan
  - [x] Panel shows assignee overdue counts sorted by count desc
  - [x] Empty state shows 'No overdue tasks' when none overdue
  - [x] Stats refresh after moving/deleting a task
  - [x] Switching boards updates the panel