### PR TITLE
Title: feat: offline write queue with replay on reconnect (#93)

### DIFF
--- a/client/src/components/Board.jsx
+++ b/client/src/components/Board.jsx
@@ -2,10 +2,19 @@ import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useTasks } from "../hooks/useTasks";
 import { updateTaskStatus, deleteTask } from "../api/tasks";
-import { putTask, removeTask } from "../db/localDB";
+import { putTask, removeTask, enqueueWrite } from "../db/localDB";
 import Column from "./Column";
 import FilterBar from "./FilterBar";
 import { filterTasks } from "../utils/filterTasks";
+
+function isNetworkError(err) {
+  return (
+    err.message === "Failed to fetch" ||
+    err.message === "NetworkError when attempting to fetch resource." ||
+    err.message === "Network request failed" ||
+    !navigator.onLine
+  );
+}
 
 const COLUMNS = [
   { key: "todo", label: "To Do" },
@@ -39,7 +48,14 @@ export default function Board() {
       const task = tasks.find((t) => t.id === id);
       if (task) putTask({ ...task, status });
     } catch (err) {
-      setActionError(err.message || "Failed to move task");
+      if (isNetworkError(err)) {
+        dispatch({ type: "moved", id, status });
+        const task = tasks.find((t) => t.id === id);
+        if (task) putTask({ ...task, status });
+        enqueueWrite({ type: "move", payload: { id, status } });
+      } else {
+        setActionError(err.message || "Failed to move task");
+      }
     }
   };
   const handleDelete = async (id) => {
@@ -48,7 +64,13 @@ export default function Board() {
       dispatch({ type: "deleted", id });
       removeTask(id);
     } catch (err) {
-      setActionError(err.message || "Failed to delete task");
+      if (isNetworkError(err)) {
+        dispatch({ type: "deleted", id });
+        removeTask(id);
+        enqueueWrite({ type: "delete", payload: { id } });
+      } else {
+        setActionError(err.message || "Failed to delete task");
+      }
     }
   };
 

--- a/client/src/context/TasksProvider.jsx
+++ b/client/src/context/TasksProvider.jsx
@@ -3,6 +3,10 @@ import { TasksContext } from "./TasksContext";
 import { getTasks } from "../api/tasks";
 import { useBoard } from "../hooks/useBoard";
 import { getLocalTasks, reconcileTasks } from "../db/localDB";
+import {
+  startOnlineListener,
+  setOnReplayComplete,
+} from "../db/outbox";
 
 function tasksReducer(state, action) {
   switch (action.type) {
@@ -80,6 +84,19 @@ export function TasksProvider({ children }) {
 
   useEffect(() => {
     loadTasks();
+  }, [loadTasks]);
+
+  // Wire offline queue replay on reconnect
+  useEffect(() => {
+    setOnReplayComplete((conflicts) => {
+      if (conflicts.length > 0) {
+        console.warn("Sync conflicts:", conflicts);
+      }
+      // Refresh tasks from server after replay
+      loadTasks();
+    });
+    const cleanup = startOnlineListener();
+    return cleanup;
   }, [loadTasks]);
 
   function retry() {

--- a/client/src/db/localDB.js
+++ b/client/src/db/localDB.js
@@ -111,6 +111,34 @@ export async function removeTask(id) {
   }
 }
 
+// --- Outbox (offline write queue) ---
+
+export async function enqueueWrite(intent) {
+  const doc = {
+    _id: `pending:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,
+    data: intent,
+  };
+  await db.put(doc);
+}
+
+export async function getPendingWrites() {
+  const result = await db.allDocs({
+    startkey: "pending:",
+    endkey: "pending:\ufff0",
+    include_docs: true,
+  });
+  return result.rows.map((r) => ({ _id: r.doc._id, _rev: r.doc._rev, ...r.doc.data }));
+}
+
+export async function removePendingWrite(id) {
+  try {
+    const doc = await db.get(id);
+    await db.remove(doc);
+  } catch {
+    // already removed
+  }
+}
+
 // --- Cleanup ---
 
 export async function clearAll() {

--- a/client/src/db/outbox.js
+++ b/client/src/db/outbox.js
@@ -1,0 +1,57 @@
+import { getPendingWrites, removePendingWrite } from "./localDB.js";
+import { createTask, updateTaskStatus, deleteTask } from "../api/tasks.js";
+
+export async function replayQueue() {
+  const pending = await getPendingWrites();
+  const conflicts = [];
+
+  for (const entry of pending) {
+    try {
+      switch (entry.type) {
+        case "create":
+          await createTask(entry.payload);
+          break;
+        case "move":
+          await updateTaskStatus(entry.payload.id, entry.payload.status);
+          break;
+        case "delete":
+          await deleteTask(entry.payload.id);
+          break;
+      }
+      await removePendingWrite(entry._id);
+    } catch (err) {
+      if (err.status === 409) {
+        conflicts.push({ entry, details: err.details });
+        await removePendingWrite(entry._id);
+      } else {
+        // Network still down — stop replay, keep remaining in queue
+        break;
+      }
+    }
+  }
+
+  return conflicts;
+}
+
+let replayInProgress = false;
+let onReplayComplete = null;
+
+export function setOnReplayComplete(callback) {
+  onReplayComplete = callback;
+}
+
+async function handleOnline() {
+  if (replayInProgress) return;
+  replayInProgress = true;
+  try {
+    const conflicts = await replayQueue();
+    if (onReplayComplete) onReplayComplete(conflicts);
+  } finally {
+    replayInProgress = false;
+  }
+}
+
+export function startOnlineListener() {
+  window.addEventListener("online", handleOnline);
+  return () => window.removeEventListener("online", handleOnline);
+}

--- a/client/src/pages/NewTaskPage.jsx
+++ b/client/src/pages/NewTaskPage.jsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { createTask } from "../api/tasks";
-import { putTask } from "../db/localDB";
+import { putTask, enqueueWrite } from "../db/localDB";
 import { useTasks } from "../hooks/useTasks";
 import Button from "../components/Button";
 import DueDateCalendar from "../components/DueDateCalendar";
@@ -44,15 +44,28 @@ export default function NewTaskPage() {
     if (Object.keys(validationErrors).length > 0) return;
 
     setSubmitting(true);
-    const task = await createTask({
+    const payload = {
       boardId,
       title: title.trim(),
       assignee: assignee.trim() || "Unassigned",
       status: "todo",
       dueDate,
-    });
-    dispatch({ type: "added", task });
-    putTask(task);
+    };
+    try {
+      const task = await createTask(payload);
+      dispatch({ type: "added", task });
+      putTask(task);
+    } catch (err) {
+      if (!navigator.onLine || err.message === "Failed to fetch") {
+        const tempTask = { ...payload, id: `temp-${Date.now()}` };
+        dispatch({ type: "added", task: tempTask });
+        putTask(tempTask);
+        enqueueWrite({ type: "create", payload });
+      } else {
+        setSubmitting(false);
+        return;
+      }
+    }
     navigate("/");
   }
 


### PR DESCRIPTION
 Closes #93

  ## Changes
  - Added outbox functions (`enqueueWrite`, `getPendingWrites`, `removePendingWrite`) to localDB.js
  - Created `outbox.js` with `replayQueue()` and `startOnlineListener()`
  - Board.jsx: move/delete operations queue offline and apply optimistically
  - NewTaskPage.jsx: create operations queue offline with temp ID
  - TasksProvider.jsx: wires replay on reconnect, refreshes tasks after sync